### PR TITLE
Update SystemOptions.as

### DIFF
--- a/src/de/flintfabrik/starling/display/FFParticleSystem/SystemOptions.as
+++ b/src/de/flintfabrik/starling/display/FFParticleSystem/SystemOptions.as
@@ -500,11 +500,11 @@ package de.flintfabrik.starling.display.FFParticleSystem
 				
 				node = config.animation.randomStartFrames;
 				if (node.length())
-					target.randomStartFrames = getIntValue(node);
+					target.randomStartFrames = getIntValue(node) as Boolean;
 			}
 			node = config.tinted;
 			if (node.length())
-				target.tinted = getIntValue(node);
+				target.tinted = getIntValue(node) as Boolean;
 			node = config.spawnTime;
 			if (node.length())
 				target.spawnTime = getFloatValue(node);


### PR DESCRIPTION
Functions returning int values instead of Boolean are causing compiler warnings! Forcefully casting the result to Boolean fixes the issue.
